### PR TITLE
RecoverCompact and SignCompact now use the btcec.PrivateKey and btcec.Pu...

### DIFF
--- a/signature_test.go
+++ b/signature_test.go
@@ -427,7 +427,8 @@ func TestSignatureSerialize(t *testing.T) {
 
 func testSignCompact(t *testing.T, tag string, curve *btcec.KoblitzCurve,
 	data []byte, isCompressed bool) {
-	priv, _ := ecdsa.GenerateKey(curve, rand.Reader)
+	tmp, _ := ecdsa.GenerateKey(curve, rand.Reader)
+	priv := (*btcec.PrivateKey)(tmp)
 
 	hashed := []byte("testing")
 	sig, err := btcec.SignCompact(curve, priv, hashed, isCompressed)


### PR DESCRIPTION
...blicKey types.

btcwallet/rpcserver.go needs a corresponding change or else it won't compile.

This closes #6
