### PR TITLE
Optimize ScalarMult with NAF

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -57,6 +57,16 @@ func BenchmarkScalarBaseMult(b *testing.B) {
 	}
 }
 
+// BenchmarkScalarBaseMultLarge benchmarks the secp256k1 curve ScalarBaseMult
+// function with abnormally large k values.
+func BenchmarkScalarBaseMultLarge(b *testing.B) {
+	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c005751111111011111110")
+	curve := btcec.S256()
+	for i := 0; i < b.N; i++ {
+		curve.ScalarBaseMult(k.Bytes())
+	}
+}
+
 // BenchmarkScalarMult benchmarks the secp256k1 curve ScalarMult function.
 func BenchmarkScalarMult(b *testing.B) {
 	x := fromHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")

--- a/bench_test.go
+++ b/bench_test.go
@@ -78,6 +78,14 @@ func BenchmarkScalarMult(b *testing.B) {
 	}
 }
 
+// BenchmarkNAF benchmarks the NAF function.
+func BenchmarkNAF(b *testing.B) {
+	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
+	for i := 0; i < b.N; i++ {
+		btcec.NAF(k.Bytes())
+	}
+}
+
 // BenchmarkSigVerify benchmarks how long it takes the secp256k1 curve to
 // verify signatures.
 func BenchmarkSigVerify(b *testing.B) {

--- a/gensecp256k1.go
+++ b/gensecp256k1.go
@@ -35,15 +35,14 @@ func (curve *KoblitzCurve) getDoublingPoints() [][3]fieldVal {
 // the possible points per 8-bit window.  This is used to when generating
 // secp256k1.go.
 func (curve *KoblitzCurve) SerializedBytePoints() []byte {
-	byteSize := curve.BitSize / 8
 	doublingPoints := curve.getDoublingPoints()
 
 	// Segregate the bits into byte-sized windows
-	serialized := make([]byte, byteSize*256*3*10*4)
+	serialized := make([]byte, curve.byteSize*256*3*10*4)
 	offset := 0
-	for byteNum := 0; byteNum < byteSize; byteNum++ {
+	for byteNum := 0; byteNum < curve.byteSize; byteNum++ {
 		// Grab the 8 bits that make up this byte from doublingPoints.
-		startingBit := 8 * (byteSize - byteNum - 1)
+		startingBit := 8 * (curve.byteSize - byteNum - 1)
 		computingPoints := doublingPoints[startingBit : startingBit+8]
 
 		// Compute all points in this window and serialize them.

--- a/gensecp256k1.go
+++ b/gensecp256k1.go
@@ -18,8 +18,7 @@ var secp256k1BytePoints = []byte{}
 // 0..n-1 where n is the curve's bit size (256 in the case of secp256k1)
 // the coordinates are recorded as Jacobian coordinates.
 func (curve *KoblitzCurve) getDoublingPoints() [][3]fieldVal {
-	bitSize := curve.Params().BitSize
-	doublingPoints := make([][3]fieldVal, bitSize)
+	doublingPoints := make([][3]fieldVal, curve.BitSize)
 
 	// initialize px, py, pz to the Jacobian coordinates for the base point
 	px, py := curve.bigAffineToField(curve.Gx, curve.Gy)
@@ -36,8 +35,7 @@ func (curve *KoblitzCurve) getDoublingPoints() [][3]fieldVal {
 // the possible points per 8-bit window.  This is used to when generating
 // secp256k1.go.
 func (curve *KoblitzCurve) SerializedBytePoints() []byte {
-	bitSize := curve.Params().BitSize
-	byteSize := bitSize / 8
+	byteSize := curve.BitSize / 8
 	doublingPoints := curve.getDoublingPoints()
 
 	// Segregate the bits into byte-sized windows

--- a/signature.go
+++ b/signature.go
@@ -340,7 +340,7 @@ func SignCompact(curve *KoblitzCurve, key *PrivateKey,
 	for i := 0; i < (curve.H+1)*2; i++ {
 		pk, err := recoverKeyFromSignature(curve, sig, hash, i, true)
 		if err == nil && pk.X.Cmp(key.X) == 0 && pk.Y.Cmp(key.Y) == 0 {
-			result := make([]byte, 1, 2*(curve.BitSize/8)+1)
+			result := make([]byte, 1, 2*curve.byteSize+1)
 			result[0] = 27 + byte(i)
 			if isCompressedKey {
 				result[0] += 4


### PR DESCRIPTION
Use Non-Adjacent Form (NAF) of large numbers to reduce ScalarMult computation times.

Preliminary results indicate around a 8-9% speed improvement according to BenchmarkScalarMult.

The algorithm used is 3.77 from Guide to Elliptical Curve Crytography by Hankerson, et al.

This closes #3 