### PR TITLE
Use btcec structs instead of ecdsa structs everywhere

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -5,7 +5,6 @@
 package btcec_test
 
 import (
-	"crypto/ecdsa"
 	"testing"
 
 	"github.com/conformal/btcec"
@@ -75,7 +74,7 @@ func BenchmarkSigVerify(b *testing.B) {
 	b.StopTimer()
 	// Randomly generated keypair.
 	// Private key: 9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d
-	pubKey := ecdsa.PublicKey{
+	pubKey := btcec.PublicKey{
 		Curve: btcec.S256(),
 		X:     fromHex("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
 		Y:     fromHex("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
@@ -83,16 +82,18 @@ func BenchmarkSigVerify(b *testing.B) {
 
 	// Double sha256 of []byte{0x01, 0x02, 0x03, 0x04}
 	msgHash := fromHex("8de472e2399610baaa7f84840547cd409434e31f5d3bd71e4d947f283874f9c0")
-	sigR := fromHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c")
-	sigS := fromHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f")
+	sig := btcec.Signature{
+		R: fromHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
+		S: fromHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
+	}
 
-	if !ecdsa.Verify(&pubKey, msgHash.Bytes(), sigR, sigS) {
+	if !sig.Verify(msgHash.Bytes(), &pubKey) {
 		b.Errorf("Signature failed to verify")
 		return
 	}
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		ecdsa.Verify(&pubKey, msgHash.Bytes(), sigR, sigS)
+		sig.Verify(msgHash.Bytes(), &pubKey)
 	}
 }

--- a/privkey.go
+++ b/privkey.go
@@ -33,6 +33,21 @@ func PrivKeyFromBytes(curve *KoblitzCurve, pk []byte) (*PrivateKey,
 	return (*PrivateKey)(priv), (*PublicKey)(&priv.PublicKey)
 }
 
+// NewPrivateKey is a wrapper for ecdsa.GenerateKey that returns a PrivateKey
+// instead of the normal ecdsa.PrivateKey.
+func NewPrivateKey(curve *KoblitzCurve) (*PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return (*PrivateKey)(key), nil
+}
+
+// PubKey returns the PublicKey corresponding to this private key.
+func (p *PrivateKey) PubKey() *PublicKey {
+	return (*PublicKey)(&p.PublicKey)
+}
+
 // ToECDSA returns the private key as a *ecdsa.PrivateKey.
 func (p *PrivateKey) ToECDSA() *ecdsa.PrivateKey {
 	return (*ecdsa.PrivateKey)(p)

--- a/signature_test.go
+++ b/signature_test.go
@@ -6,7 +6,6 @@ package btcec_test
 
 import (
 	"bytes"
-	"crypto/ecdsa"
 	"crypto/rand"
 	"fmt"
 	"math/big"
@@ -427,7 +426,7 @@ func TestSignatureSerialize(t *testing.T) {
 
 func testSignCompact(t *testing.T, tag string, curve *btcec.KoblitzCurve,
 	data []byte, isCompressed bool) {
-	tmp, _ := ecdsa.GenerateKey(curve, rand.Reader)
+	tmp, _ := btcec.NewPrivateKey(curve)
 	priv := (*btcec.PrivateKey)(tmp)
 
 	hashed := []byte("testing")


### PR DESCRIPTION
This change should make it so that only btcec relies on the crypto/ecdsa package for secp256k1 math.
